### PR TITLE
Added support for new paper elements in paper-dropdown-menu.

### DIFF
--- a/ajax-form.js
+++ b/ajax-form.js
@@ -103,8 +103,8 @@
         maybeParseCoreDropdownMenu = function(customElement, data) {
             if (customElement.tagName.toLowerCase() === 'core-dropdown-menu' ||
                 customElement.tagName.toLowerCase() === 'paper-dropdown-menu') {
-                var coreMenu = customElement.querySelector('core-menu'),
-                    selectedItem = coreMenu && coreMenu.selectedItem;
+                var menuContainer = customElement.querySelector('core-menu,paper-menu,paper-list-box'),
+                    selectedItem = menuContainer && menuContainer.selectedItem;
 
                 if (selectedItem) {
                     processFormValue(customElement.getAttribute('name'), selectedItem.label || selectedItem.textContent, data);


### PR DESCRIPTION
core-menu will be deprecated as per https://github.com/Polymer/core-menu.  paper-dropdown-menu can contain any element that acts like iron-selector, so paper-menu and paper-list-box have been added.